### PR TITLE
Fix build/test/clippy errors, update all dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ rust:
 - nightly
 matrix:
   allow_failures:
-    - rust: 
+    - rust:
       - beta
       - nightly
-  fast_finish: true    
+  fast_finish: true
 env:
 - FEATURES=default
 - FEATURES=rust-native-tls

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,5 @@ before_install:
   -in auth_token.enc -out tests/auth_token -d
 - cp tests/auth_token github-gql-rs/tests/auth_token
 script:
-- cargo build --no-default-features --features "$FEATURES"
-- cargo test
-- cd github-gql-rs
-- cargo build --no-default-features --features "$FEATURES"
-- cargo test
+- cargo build --no-default-features --features "$FEATURES" --all
+- cargo test --all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,18 +18,18 @@ travis-ci = { repository = "github-rs/github-rs", branch = "master" }
 appveyor = { repository = "github-rs/github-rs", branch = "master", service = "github" }
 
 [dependencies]
-hyper = "0.12"
-hyper-rustls = { version = "0.15", optional = true }
-hyper-tls = { version = "0.3", optional = true }
-native-tls = { version = "0.2", optional = true }
-error-chain = "0.12"
-tokio-core = "0.1"
-futures = "0.1"
-serde = "1.0"
-serde_json = "1.0"
+hyper = "0.12.27"
+hyper-rustls = { version = "0.16.1", optional = true }
+hyper-tls = { version = "0.3.2", optional = true }
+native-tls = { version = "0.2.2", optional = true }
+error-chain = "0.12.0"
+tokio-core = "0.1.17"
+futures = "0.1.26"
+serde = "1.0.90"
+serde_json = "1.0.39"
 
 [dev-dependencies]
-serde_derive = "1.0"
+serde_derive = "1.0.90"
 
 [workspace]
 members = ["github-gql-rs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 repository = "https://github.com/github-rs/github-rs.git"
 homepage = "https://github.com/github-rs/github-rs"
 documentation = "https://docs.rs/github-rs/"
+edition = "2018"
 
 [features]
 default = ["rustls"]

--- a/README.md
+++ b/README.md
@@ -73,8 +73,6 @@ serde_json = "1.0"
 Then in your `lib.rs` or `main.rs` file add:
 
 ```rust
-extern crate github_rs;
-extern crate serde_json;
 use github_rs::client::{Executor, Github};
 use serde_json::Value;
 ```
@@ -83,8 +81,6 @@ Now you can start making queries. Here's a small example to get your user
 information:
 
 ```rust
-extern crate github_rs;
-extern crate serde_json;
 use github_rs::client::{Executor, Github};
 use serde_json::Value;
 

--- a/examples/cached_responses.rs
+++ b/examples/cached_responses.rs
@@ -1,5 +1,3 @@
-extern crate github_rs;
-extern crate serde_json;
 use github_rs::client::{Executor, Github};
 use github_rs::headers::{etag, rate_limit_remaining};
 use serde_json::Value;

--- a/examples/custom_endpoint_and_adding_headers.rs
+++ b/examples/custom_endpoint_and_adding_headers.rs
@@ -1,6 +1,3 @@
-extern crate github_rs;
-extern crate hyper;
-extern crate serde_json;
 use github_rs::client::{Executor, Github};
 use github_rs::{HeaderMap, StatusCode};
 use hyper::header::{HeaderValue, ACCEPT};

--- a/examples/getting_started.rs
+++ b/examples/getting_started.rs
@@ -1,5 +1,3 @@
-extern crate github_rs;
-extern crate serde_json;
 use github_rs::client::{Executor, Github};
 use serde_json::Value;
 

--- a/examples/wrapping_responses.rs
+++ b/examples/wrapping_responses.rs
@@ -1,7 +1,5 @@
-extern crate github_rs;
 #[macro_use]
 extern crate serde_derive;
-extern crate serde_json;
 
 use github_rs::client::{Executor, Github};
 use github_rs::StatusCode;

--- a/github-gql-rs/Cargo.toml
+++ b/github-gql-rs/Cargo.toml
@@ -24,15 +24,15 @@ appveyor = { repository = "github-rs/github-rs", branch = "master", service = "g
 name = "github_gql"
 
 [dependencies]
-hyper = "0.12"
-hyper-rustls = { version = "0.15", optional = true }
-hyper-tls = { version = "0.3", optional = true }
-native-tls = { version = "0.2", optional = true }
-error-chain = "0.11"
-tokio-core = "0.1"
-futures = "0.1"
-serde = "1.0"
-serde_json = "1.0"
+hyper = "0.12.27"
+hyper-rustls = { version = "0.16.1", optional = true }
+hyper-tls = { version = "0.3.2", optional = true }
+native-tls = { version = "0.2.2", optional = true }
+error-chain = "0.12.0"
+tokio-core = "0.1.17"
+futures = "0.1.26"
+serde = "1.0.90"
+serde_json = "1.0.39"
 
 [dev-dependencies]
-serde_derive = "1.0"
+serde_derive = "1.0.90"

--- a/github-gql-rs/Cargo.toml
+++ b/github-gql-rs/Cargo.toml
@@ -10,6 +10,7 @@ documentation = "https://docs.rs/github-rs/"
 readme = "README.md"
 keywords = []
 categories = []
+edition = "2018"
 
 [features]
 default = ["rustls"]

--- a/github-gql-rs/README.md
+++ b/github-gql-rs/README.md
@@ -39,7 +39,6 @@ github-gql-rs = "0.0.1"
 Then in your `lib.rs` or `main.rs` file add:
 
 ```rust
-extern crate github_gql;
 use github_gql::client::Github;
 ```
 
@@ -47,8 +46,7 @@ Now you can start making queries. Here's a small example to get your user
 information:
 
 ```rust
-extern crate github_gql as gh;
-extern crate serde_json;
+use github_gql as gh;
 use gh::client::Github;
 use gh::query::Query;
 use serde_json::Value;

--- a/github-gql-rs/src/client.rs
+++ b/github-gql-rs/src/client.rs
@@ -19,10 +19,10 @@ type HttpsConnector = hyper_tls::HttpsConnector<hyper::client::HttpConnector>;
 use serde::de::DeserializeOwned;
 
 // Lib Imports
-use errors::*;
-use mutation::Mutation;
-use query::Query;
-use IntoGithubRequest;
+use crate::errors::*;
+use crate::mutation::Mutation;
+use crate::query::Query;
+use crate::IntoGithubRequest;
 
 // Std Imports
 use std::cell::RefCell;
@@ -54,11 +54,10 @@ impl Github {
         T: ToString,
     {
         let core = Core::new()?;
-        let handle = core.handle();
         #[cfg(feature = "rustls")]
         let client = Client::builder().build(HttpsConnector::new(4));
         #[cfg(feature = "rust-native-tls")]
-        let client = Client::builder().build(HttpsConnector::new(4, &handle)?);
+        let client = Client::builder().build(HttpsConnector::new(4)?);
         Ok(Self {
             token: token.to_string(),
             core: Rc::new(RefCell::new(core)),

--- a/github-gql-rs/src/lib.rs
+++ b/github-gql-rs/src/lib.rs
@@ -2,17 +2,6 @@
 
 #[macro_use]
 extern crate error_chain;
-extern crate futures;
-extern crate hyper;
-#[cfg(feature = "rustls")]
-extern crate hyper_rustls;
-#[cfg(feature = "rust-native-tls")]
-extern crate hyper_tls;
-#[cfg(feature = "rust-native-tls")]
-extern crate native_tls;
-extern crate serde;
-extern crate serde_json;
-extern crate tokio_core;
 
 #[allow(deprecated)] // error_chain uses cause()
 pub mod errors {

--- a/github-gql-rs/src/mutation.rs
+++ b/github-gql-rs/src/mutation.rs
@@ -1,9 +1,10 @@
 use crate::errors::*;
+use crate::IntoGithubRequest;
 use hyper::header::{HeaderValue, AUTHORIZATION, CONTENT_TYPE, USER_AGENT};
 use hyper::Request;
-use crate::IntoGithubRequest;
 
 /// Used to mutate information on GitHub
+#[derive(Default)]
 pub struct Mutation {
     pub(crate) mutation: String,
 }
@@ -61,7 +62,7 @@ impl IntoGithubRequest for Mutation {
             .uri("https://api.github.com/graphql")
             .body(q.into())
             .chain_err(|| "Unable to for URL to make the request")?;
-        let token = String::from("token ") + &token;
+        let token = String::from("token ") + token;
         {
             let headers = req.headers_mut();
             headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));

--- a/github-gql-rs/src/mutation.rs
+++ b/github-gql-rs/src/mutation.rs
@@ -1,8 +1,7 @@
-use errors::*;
+use crate::errors::*;
 use hyper::header::{HeaderValue, AUTHORIZATION, CONTENT_TYPE, USER_AGENT};
 use hyper::Request;
-use std::str::FromStr;
-use IntoGithubRequest;
+use crate::IntoGithubRequest;
 
 /// Used to mutate information on GitHub
 pub struct Mutation {

--- a/github-gql-rs/src/query.rs
+++ b/github-gql-rs/src/query.rs
@@ -1,7 +1,7 @@
-use errors::*;
+use crate::errors::*;
 use hyper::header::{HeaderValue, AUTHORIZATION, CONTENT_TYPE, USER_AGENT};
-use hyper::{Method, Request, Uri};
-use IntoGithubRequest;
+use hyper::Request;
+use crate::IntoGithubRequest;
 
 /// Used to query information from the GitHub API to possibly be used in
 /// a `Mutation` or for information to make decisions with how to interact.

--- a/github-gql-rs/src/query.rs
+++ b/github-gql-rs/src/query.rs
@@ -1,10 +1,11 @@
 use crate::errors::*;
+use crate::IntoGithubRequest;
 use hyper::header::{HeaderValue, AUTHORIZATION, CONTENT_TYPE, USER_AGENT};
 use hyper::Request;
-use crate::IntoGithubRequest;
 
 /// Used to query information from the GitHub API to possibly be used in
 /// a `Mutation` or for information to make decisions with how to interact.
+#[derive(Default)]
 pub struct Query {
     pub(crate) query: String,
 }
@@ -67,7 +68,7 @@ impl IntoGithubRequest for Query {
             .body(q.into())
             .chain_err(|| "Unable to for URL to make the request")?;
 
-        let token = String::from("token ") + &token;
+        let token = String::from("token ") + token;
         {
             let headers = req.headers_mut();
             headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));

--- a/github-gql-rs/tests/users.rs
+++ b/github-gql-rs/tests/users.rs
@@ -1,5 +1,4 @@
-extern crate github_gql as gh;
-extern crate serde_json;
+use github_gql as gh;
 use gh::client::Github;
 use gh::query::Query;
 use serde_json::Value;

--- a/github-gql-rs/tests/users.rs
+++ b/github-gql-rs/tests/users.rs
@@ -1,6 +1,6 @@
-use github_gql as gh;
 use gh::client::Github;
 use gh::query::Query;
+use github_gql as gh;
 use serde_json::Value;
 use std::fs::File;
 use std::io::prelude::*;

--- a/github-gql-rs/tests/users.rs
+++ b/github-gql-rs/tests/users.rs
@@ -12,7 +12,8 @@ fn auth_token() -> Result<String, std::io::Error> {
     let file = File::open("tests/auth_token")?;
     let mut reader = BufReader::new(file);
     let mut buffer = String::new();
-    let _ = reader.read_line(&mut buffer)?;
+    reader.read_line(&mut buffer)?;
+    buffer = buffer.trim_end().to_string();
     Ok(buffer)
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -21,14 +21,14 @@ use serde::Serialize;
 use serde_json;
 
 // Internal Library Imports
-use errors::*;
-use gists;
-use misc;
-use notifications;
-use orgs;
-use repos;
-use users;
-use util::url_join;
+use crate::errors::*;
+use crate::gists;
+use crate::misc;
+use crate::notifications;
+use crate::orgs;
+use crate::repos;
+use crate::users;
+use crate::util::url_join;
 
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/src/client.rs
+++ b/src/client.rs
@@ -88,7 +88,7 @@ impl Github {
         #[cfg(feature = "rustls")]
         let client = Client::builder().build(HttpsConnector::new(4));
         #[cfg(feature = "rust-native-tls")]
-        let client = Client::builder().build(HttpsConnector::new(4, &handle)?);
+        let client = Client::builder().build(HttpsConnector::new(4)?);
         Ok(Self {
             token: token.to_string(),
             core: Rc::new(RefCell::new(core)),

--- a/src/client.rs
+++ b/src/client.rs
@@ -50,22 +50,16 @@ impl Clone for Github {
     }
 }
 
-/// All GET based queries can be constructed from this type
 new_type!(GetQueryBuilder);
 
-/// All PUT based queries can be constructed from this type
 new_type!(PutQueryBuilder);
 
-/// All POST based queries can be constructed from this type
 new_type!(PostQueryBuilder);
 
-/// All DELETE based queries can be constructed from this type
 new_type!(DeleteQueryBuilder);
 
-/// All PATCH based queries can be constructed from this type
 new_type!(PatchQueryBuilder);
 
-/// Queries for endpoints that aren't in this library can be crafted here
 new_type!(CustomQuery);
 
 exec!(CustomQuery);

--- a/src/gists/delete.rs
+++ b/src/gists/delete.rs
@@ -1,6 +1,6 @@
 //! Access the Gists portion of the Github API
 imports!();
-use client::DeleteQueryBuilder;
+use crate::client::DeleteQueryBuilder;
 
 new_type!(
     Gists

--- a/src/gists/get.rs
+++ b/src/gists/get.rs
@@ -1,6 +1,6 @@
 //! Access the Gists portion of the Github API
 imports!();
-use client::GetQueryBuilder;
+use crate::client::GetQueryBuilder;
 
 new_type!(
     Gists

--- a/src/gists/patch.rs
+++ b/src/gists/patch.rs
@@ -1,6 +1,6 @@
 //! Access the Gists portion of the GitHub API
 imports!();
-use client::PatchQueryBuilder;
+use crate::client::PatchQueryBuilder;
 
 new_type!(
     Gists

--- a/src/gists/post.rs
+++ b/src/gists/post.rs
@@ -1,6 +1,6 @@
 //! Access the Gists portion of the Github API
 imports!();
-use client::PostQueryBuilder;
+use crate::client::PostQueryBuilder;
 
 new_type!(
     Gists

--- a/src/gists/put.rs
+++ b/src/gists/put.rs
@@ -1,6 +1,6 @@
 //! Access the Gists portion of the GitHub API
 imports!();
-use client::PutQueryBuilder;
+use crate::client::PutQueryBuilder;
 
 new_type!(
     Gists

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,17 +7,6 @@
 
 #[macro_use]
 extern crate error_chain;
-extern crate futures;
-extern crate hyper;
-#[cfg(feature = "rustls")]
-extern crate hyper_rustls;
-#[cfg(feature = "native-tls")]
-extern crate hyper_tls;
-#[cfg(feature = "native-tls")]
-extern crate native_tls;
-extern crate serde;
-extern crate serde_json;
-extern crate tokio_core;
 
 #[macro_use]
 mod macros;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -309,7 +309,7 @@ macro_rules! imports {
         use hyper_tls;
         #[cfg(feature = "rust-native-tls")]
         type HttpsConnector = hyper_tls::HttpsConnector<hyper::client::HttpConnector>;
-        use errors::*;
+        use crate::errors::*;
         use futures::future::ok;
         use futures::{Future, Stream};
         use hyper::client::Client;
@@ -320,7 +320,7 @@ macro_rules! imports {
         use serde_json;
         use std::cell::RefCell;
         use std::rc::Rc;
-        use util::url_join;
+        use crate::util::url_join;
 
         use $crate::client::Executor;
     };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -310,6 +310,7 @@ macro_rules! imports {
         #[cfg(feature = "rust-native-tls")]
         type HttpsConnector = hyper_tls::HttpsConnector<hyper::client::HttpConnector>;
         use crate::errors::*;
+        use crate::util::url_join;
         use futures::future::ok;
         use futures::{Future, Stream};
         use hyper::client::Client;
@@ -320,7 +321,6 @@ macro_rules! imports {
         use serde_json;
         use std::cell::RefCell;
         use std::rc::Rc;
-        use crate::util::url_join;
 
         use $crate::client::Executor;
     };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -315,7 +315,6 @@ macro_rules! imports {
         use hyper::client::Client;
         use hyper::Request;
         use hyper::StatusCode;
-        #[allow(unused)]
         use hyper::{self, Body, HeaderMap};
         use serde::de::DeserializeOwned;
         use serde_json;

--- a/src/misc/get.rs
+++ b/src/misc/get.rs
@@ -1,6 +1,6 @@
 //! Access the Misc portion of the GitHub API
 imports!();
-use client::GetQueryBuilder;
+use crate::client::GetQueryBuilder;
 
 new_type!(
     Emojis

--- a/src/notifications/delete.rs
+++ b/src/notifications/delete.rs
@@ -1,7 +1,7 @@
 //! Access the (notifications)[https://developer.github.com/v3/activity/notifications/]
 //! portion of the GitHub API
 imports!();
-use client::DeleteQueryBuilder;
+use crate::client::DeleteQueryBuilder;
 
 new_type!(
     Notifications

--- a/src/notifications/get.rs
+++ b/src/notifications/get.rs
@@ -1,7 +1,7 @@
 //! Access the (notifications)[https://developer.github.com/v3/activity/notifications/]
 //! portion of the GitHub API
 imports!();
-use client::GetQueryBuilder;
+use crate::client::GetQueryBuilder;
 
 new_type!(
     Notifications

--- a/src/notifications/patch.rs
+++ b/src/notifications/patch.rs
@@ -1,7 +1,7 @@
 //! Access the (notifications)[https://developer.github.com/v3/activity/notifications/]
 //! portion of the GitHub API
 imports!();
-use client::PatchQueryBuilder;
+use crate::client::PatchQueryBuilder;
 
 new_type!(
     Notifications

--- a/src/notifications/put.rs
+++ b/src/notifications/put.rs
@@ -1,7 +1,7 @@
 //! Access the (notifications)[https://developer.github.com/v3/activity/notifications/]
 //! portion of the GitHub API
 imports!();
-use client::PutQueryBuilder;
+use crate::client::PutQueryBuilder;
 
 new_type!(
     Notifications

--- a/src/orgs/get.rs
+++ b/src/orgs/get.rs
@@ -1,6 +1,6 @@
 //! Access the Organizations portion of the Github API
 imports!();
-use client::GetQueryBuilder;
+use crate::client::GetQueryBuilder;
 
 new_type!(
     Orgs

--- a/src/repos/get.rs
+++ b/src/repos/get.rs
@@ -1,6 +1,6 @@
 //! Access the Repos portion of the GitHub API
 imports!();
-use client::GetQueryBuilder;
+use crate::client::GetQueryBuilder;
 
 new_type!(
     ArchiveReference

--- a/src/repos/post.rs
+++ b/src/repos/post.rs
@@ -1,6 +1,6 @@
 //! Access the Repos portion of the GitHub API
 imports!();
-use client::PostQueryBuilder;
+use crate::client::PostQueryBuilder;
 
 new_type!(
     Sha

--- a/src/users/delete.rs
+++ b/src/users/delete.rs
@@ -1,6 +1,6 @@
 //! Access the Users portion of the GitHub API
 imports!();
-use client::DeleteQueryBuilder;
+use crate::client::DeleteQueryBuilder;
 
 new_type!(
     User

--- a/src/users/get.rs
+++ b/src/users/get.rs
@@ -1,6 +1,6 @@
 //! Access the Users portion of the GitHub API
 imports!();
-use client::GetQueryBuilder;
+use crate::client::GetQueryBuilder;
 
 // Declaration of types representing the various items under users
 new_type!(

--- a/src/users/patch.rs
+++ b/src/users/patch.rs
@@ -1,6 +1,6 @@
 //! Access the Users portion of the GitHub API
 imports!();
-use client::PatchQueryBuilder;
+use crate::client::PatchQueryBuilder;
 
 new_type!(
     User

--- a/src/users/post.rs
+++ b/src/users/post.rs
@@ -1,6 +1,6 @@
 //! Access the Users portion of the GitHub API
 imports!();
-use client::PostQueryBuilder;
+use crate::client::PostQueryBuilder;
 
 new_type!(
     User

--- a/src/users/put.rs
+++ b/src/users/put.rs
@@ -1,6 +1,6 @@
 //! Access the Users portion of the GitHub API
 imports!();
-use client::PutQueryBuilder;
+use crate::client::PutQueryBuilder;
 
 new_type!(
     User

--- a/tests/gitignore.rs
+++ b/tests/gitignore.rs
@@ -1,5 +1,4 @@
-extern crate github_rs as gh;
-extern crate serde_json;
+use github_rs as gh;
 use gh::client::Executor;
 use gh::StatusCode;
 use serde_json::Value;

--- a/tests/gitignore.rs
+++ b/tests/gitignore.rs
@@ -1,6 +1,6 @@
-use github_rs as gh;
 use gh::client::Executor;
 use gh::StatusCode;
+use github_rs as gh;
 use serde_json::Value;
 
 mod testutil;

--- a/tests/notifications.rs
+++ b/tests/notifications.rs
@@ -1,4 +1,4 @@
-extern crate github_rs as gh;
+use github_rs as gh;
 #[macro_use]
 extern crate serde_json;
 use gh::client::Executor;

--- a/tests/testutil.rs
+++ b/tests/testutil.rs
@@ -1,4 +1,4 @@
-extern crate github_rs as gh;
+use github_rs as gh;
 
 use gh::client::Github;
 use std::fs::File;

--- a/tests/testutil.rs
+++ b/tests/testutil.rs
@@ -19,6 +19,8 @@ fn auth_token() -> Result<String, Error> {
     let mut reader = BufReader::new(file);
     let mut buffer = String::new();
     reader.read_line(&mut buffer)?;
+    // Editors may add a newline at the end of a file, so this trims it off
+    buffer = buffer.trim_end().to_string();
     Ok(buffer)
 }
 

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -1,6 +1,6 @@
-use github_rs as gh;
 use gh::client::Executor;
 use gh::headers::{etag, rate_limit_remaining};
+use github_rs as gh;
 use serde_json::Value;
 
 mod testutil;

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -1,5 +1,4 @@
-extern crate github_rs as gh;
-extern crate serde_json;
+use github_rs as gh;
 use gh::client::Executor;
 use gh::headers::{etag, rate_limit_remaining};
 use serde_json::Value;
@@ -15,7 +14,7 @@ fn get_user_repos() {
     let (headers, status, json) = g
         .get()
         .repos()
-        .owner("mgattozzi")
+        .owner("github-rs")
         .repo("github-rs")
         .execute::<Value>()
         .expect(testutil::FAILED_GITHUB_CONNECTION);

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -33,7 +33,7 @@ fn cached_response() {
     let (headers, _, _) = g
         .get()
         .repos()
-        .owner("mgattozzi")
+        .owner("github-rs")
         .repo("github-rs")
         .execute::<Value>()
         .expect(testutil::FAILED_GITHUB_CONNECTION);
@@ -44,7 +44,7 @@ fn cached_response() {
         .get()
         .set_etag(etag.unwrap())
         .repos()
-        .owner("mgattozzi")
+        .owner("github-rs")
         .repo("github-rs")
         .execute::<Value>()
         .expect(testutil::FAILED_GITHUB_CONNECTION);


### PR DESCRIPTION
This PR fixes a number of issues I've found in the repository, listed below.

## Changes

* Updates all dependencies to their latest current release
* fixes build errors with rust-native-tls. It looks like a breaking change made it in, but was never accounted for. The concerning API is located [here](https://docs.rs/hyper-tls/0.3.2/hyper_tls/struct.HttpsConnector.html).
* trims whitespace after reading the file at `tests/auth_token`. Some editors typically include a newline character `\n` on save, so this gets around that pain point.
* fixes user tests (`github-rs` now belongs to its eponymous organization)
* fixes a hard clippy error (and some more clippy warnings in the graphql subcrate)
* fixes all clippy warnings about unused doc comments preceding a macro call
* updates the crate to use edition 2018
* removes most instances of `extern crate`
* makes Travis neater/more inclusive