### PR TITLE
Update library version recommended in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ github-rs supports [rustls] and [rust-native-tls] for TLS connectivity.
 
 ```toml
 [dependencies.github-rs]
-version = "0.6"
+version = "0.7"
 default-features = false
 features = ["rust-native-tls"]
 ```
@@ -66,7 +66,7 @@ Add the following to your `Cargo.toml`
 
 ```toml
 [dependencies]
-github-rs = "0.6"
+github-rs = "0.7"
 serde_json = "1.0"
 ```
 


### PR DESCRIPTION
`0.6` currently does not work. See: https://github.com/github-rs/github-rs/issues/163. 

Upgrading to `0.7` solves the above problem, so should be recommended in `README.dm` now. 