### PR TITLE
Paginated execute

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -99,10 +99,10 @@ where Self: Sized + 'a
         T: DeserializeOwned
     {
         let client = self.client();
-        let work = client.request(self.request()?).and_then(|res| {
-            deserialize_response(res)
-        });
-        self.core_ref().run(work).map_err(|e| e.into())?
+        let work = client.request(self.request()?)
+                         .map_err(|e| e.into())
+                         .and_then(deserialize_response);
+        self.core_ref()?.run(work)?
     }
 
     fn paginated_execute<T>(self) -> Result<Vec<(HeaderMap, StatusCode, T)>>

--- a/src/client.rs
+++ b/src/client.rs
@@ -120,7 +120,8 @@ where Self: Sized + 'a
         let client = self.client();
         let work = move |req| {
             client.request(req)
-                    .and_then(|res| {
+                  .map_err(|e| e.into())
+                  .and_then(|res| {
                 deserialize_response(res)
             })
         };
@@ -132,7 +133,7 @@ where Self: Sized + 'a
         println!("Cloned req: {:#?}", req); // XXX
         let mut results = Vec::new();
 
-        let (headers, status, body) = core_ref.run(work(request)).map_err(|e| e.into())??;
+        let (headers, status, body) = core_ref.run(work(request))??;
         results.push((headers.clone(), status, body));
         if let Some(link) = headers.get(LINK) {
             println!("Got link: {:#?}", link);  // XXX

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,5 @@
 // Tokio/Future Imports
-use futures::future::ok;
-use futures::{Future, Stream};
+use futures::Future;
 use tokio_core::reactor::Core;
 
 // Hyper Imports
@@ -68,6 +67,9 @@ pub trait Executor {
     fn execute<T>(self) -> Result<(HeaderMap, StatusCode, Option<T>)>
     where
         T: DeserializeOwned;
+    fn paginated_execute<T>(self) -> Result<Vec<(HeaderMap, StatusCode, T)>>
+        where
+            T: DeserializeOwned;
 }
 
 impl Github {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,6 +5,7 @@ error_chain! {
         Hyper(::hyper::Error);
         Http(::hyper::http::Error);
         HeaderValue(::hyper::header::InvalidHeaderValue);
+        HeaderValueToStr(::hyper::header::ToStrError);
         Uri(::hyper::http::uri::InvalidUriParts);
         HyperTls(::native_tls::Error) #[cfg(feature = "rust-native-tls")];
         Io(::std::io::Error);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -183,16 +183,16 @@ macro_rules! new_type {
 macro_rules! exec {
     ($t: ident) => {
         impl<'g> Executor<'g> for $t<'g> {
-            fn request(&self) -> Result<Request<Body>>
+            fn request(self) -> Result<Request<Body>>
             {
                 Ok(self.request?.into_inner())
             }
-            fn core_ref(self) -> Result<RefMut<'g, Core>> {
+            fn core_ref(&self) -> Result<RefMut<'g, Core>> {
                 self.core.try_borrow_mut().map_err(|e| e.into())
             }
-            fn client(&self) -> &Rc<Client<HttpsConnector>>
+            fn client(&self) -> Rc<Client<HttpsConnector>>
             {
-                self.client
+                self.client.clone()
             }
         }
     };


### PR DESCRIPTION
This restores the de-pagination logic from an old branch: https://github.com/mgattozzi/github-rs/tree/pagination

I'm not sure this is actually the best approach; as I worked on this, I realized that a much simpler way would be a variant of the `execute` method that simply includes an optional "next page" `Request` object in its output.

In order to have a nicer development experience, I moved most of the `Executor` logic into the trait definition itself, leaving only a few methods to be implemented in the `exec!` macro itself. I realize this refactoring isn't strictly related to these changes, but personally I think it's an improvement.